### PR TITLE
modified to support multiple ref_celltyped

### DIFF
--- a/xclone/model/_RDR_dispersion.py
+++ b/xclone/model/_RDR_dispersion.py
@@ -34,9 +34,13 @@ def view_celltype(Xdata, cell_anno_key = "cell_type"):
 def select_celltype(Xdata, cell_anno_key = "cell_type", select_celltype = "Paneth"):
     """
     """
-    Flag_ = Xdata.obs[cell_anno_key] == select_celltype
-    
-    update_Xdata = Xdata[Flag_, :]
+    # Flag_ = Xdata.obs[cell_anno_key] == select_celltype
+    # modified for multiple select_celltype
+    if isinstance(select_celltype, list):
+        ref_flag = Xdata.obs[cell_anno_key].isin(select_celltype)
+    else:
+        ref_flag = Xdata.obs[cell_anno_key] == select_celltype
+    update_Xdata = Xdata[ref_flag, :]
     
     return update_Xdata
 

--- a/xclone/model/_RDR_process.py
+++ b/xclone/model/_RDR_process.py
@@ -31,11 +31,28 @@ def extra_preprocess(adata, ref_celltype, cluster_key='cell_type',
     else:
         Xmtx = adata.X
     
-    if ref_celltype not in list(adata.obs[cluster_key]):
-        print("Error: %s not exist as ref cell type" %(ref_celltype))
-        return None
-        
-    _is_ref = adata.obs[cluster_key] == ref_celltype
+    # if ref_celltype not in list(adata.obs[cluster_key]):
+        # print("Error: %s not exist as ref cell type" %(ref_celltype))
+        # return None
+
+    # modified for multiple ref_celltype
+    if isinstance(ref_celltype, list):
+        missing_items = [item for item in ref_celltype if item not in list(adata.obs[cluster_key])]
+        if missing_items:
+            print("Error: The following items do not exist as ref cell types: %s" % (", ".join(missing_items)))
+            return None
+    else:
+        if ref_celltype not in list(adata.obs[cluster_key]):
+            print("Error: %s does not exist as a ref cell type" % (ref_celltype))
+            return None  
+
+    # _is_ref = adata.obs[cluster_key] == ref_celltype
+    # modified for multiple ref_celltype
+    if isinstance(ref_celltype, list):
+        _is_ref = adata.obs[cluster_key].isin(ref_celltype)
+    else:
+        _is_ref = adata.obs[cluster_key] == ref_celltype
+
     adata.var['ref_avg'] = Xmtx[_is_ref, :].mean(axis=0)
     adata.obs['counts_ratio'] = Xmtx.sum(axis=1) / adata.var['ref_avg'].sum()
 
@@ -108,11 +125,27 @@ def extra_preprocess2(adata, ref_celltype, cluster_key='cell_type',
     else:
         Xmtx = adata.X
 
-    if ref_celltype not in list(adata.obs[cluster_key]):
-        print("Error: %s not exist as ref cell type" %(ref_celltype))
-        return None
-        
-    _is_ref = adata.obs[cluster_key] == ref_celltype
+    # if ref_celltype not in list(adata.obs[cluster_key]):
+        # print("Error: %s not exist as ref cell type" %(ref_celltype))
+        # return None
+
+    # modified for multiple ref_celltype
+    if isinstance(ref_celltype, list):
+        missing_items = [item for item in ref_celltype if item not in list(adata.obs[cluster_key])]
+        if missing_items:
+            print("Error: The following items do not exist as ref cell types: %s" % (", ".join(missing_items)))
+            return None
+    else:
+        if ref_celltype not in list(adata.obs[cluster_key]):
+            print("Error: %s does not exist as a ref cell type" % (ref_celltype))
+            return None 
+
+    # _is_ref = adata.obs[cluster_key] == ref_celltype
+    # modified for multiple ref_celltype
+    if isinstance(ref_celltype, list):
+        _is_ref = adata.obs[cluster_key].isin(ref_celltype)
+    else:
+        _is_ref = adata.obs[cluster_key] == ref_celltype
 
     sorted_indices = np.argsort(adata.obsp['connectivities'], axis = -1) # cell*cell
     sorted_ref_indices = sorted_indices[:, _is_ref] # cell* ref_cell
@@ -198,7 +231,12 @@ def NMF_confounder(Xdata,
         Xdata_norm = Xdata.copy()
     
     ## NMF modelling
-    _is_ref = Xdata_norm.obs[anno_key] == ref_celltype
+    # _is_ref = Xdata_norm.obs[anno_key] == ref_celltype
+    # modified for multiple ref_celltype
+    if isinstance(ref_celltype, list):
+        _is_ref = Xdata_norm.obs[anno_key].isin(ref_celltype)
+    else:
+        _is_ref = Xdata_norm.obs[anno_key] == ref_celltype
 
     _X_norm = np.array(Xdata_norm.X) + 0.0
     

--- a/xclone/model/_RDR_smoothing.py
+++ b/xclone/model/_RDR_smoothing.py
@@ -34,7 +34,13 @@ def RDR_smoothing_base(Xdata,
     # sc.pp.normalize_total from the Scanpy library supports both dense and sparse matrices. 
     
     Xdata_norm = Xdata.copy()
-    _is_ref = Xdata_norm.obs[cell_anno_key] == ref_celltype
+
+    #_is_ref = Xdata_norm.obs[cell_anno_key] == ref_celltype
+    # modified for multiple ref_celltype
+    if isinstance(ref_celltype, list):
+        _is_ref = Xdata_norm.obs[cell_anno_key].isin(ref_celltype)
+    else:
+        _is_ref = Xdata_norm.obs[cell_anno_key] == ref_celltype
 
     # Normalize and log transform using scanpy functions
     sc.pp.normalize_total(Xdata_norm, target_sum=10000)

--- a/xclone/model/xclone_rdr_wrap.py
+++ b/xclone/model/xclone_rdr_wrap.py
@@ -168,10 +168,18 @@ def run_RDR(RDR_adata, verbose = True, run_verbose = True, config_file = None):
     cell_detection_rate = 0.05, verbose = verbose)
 
     ## check ref_celltype
-    if ref_celltype in RDR_adata.obs[cell_anno_key].values:
-        pass
+    # if ref_celltype in RDR_adata.obs[cell_anno_key].values:
+        # pass
+    # else:
+        # raise ValueError(f"[XClone error] Item '{ref_celltype}' not found in the RDR_adata's annotation.")
+    # modified for multiple ref_celltype
+    if isinstance(ref_celltype, list):
+        missing_items = [item for item in ref_celltype if item not in RDR_adata.obs[cell_anno_key].values]
+        if missing_items:
+            raise ValueError(f"[XClone error] Items {missing_items} not found in the RDR_adata's annotation.")
     else:
-        raise ValueError(f"[XClone error] Item '{ref_celltype}' not found in the RDR_adata's annotation.")
+        if ref_celltype not in RDR_adata.obs[cell_anno_key].values:
+            raise ValueError(f"[XClone error] Item '{ref_celltype}' not found in the RDR_adata's annotation.")
     
     ## Transformation for smart-seq data
     RDR_adata = xclone.pp.Xtransformation(RDR_adata, transform = smart_transform, Xlayers = ["raw_expr"])
@@ -280,15 +288,17 @@ def run_RDR(RDR_adata, verbose = True, run_verbose = True, config_file = None):
                                               KNN_neighbors = KNN_neighbors,
                                               KNN_npcs = KNN_npcs,
                                               copy=True)
-    
+
     if multi_refcelltype:
         print("multi_refcelltype")
         # update expected layer
+        '''
         RDR_adata = xclone.model.extra_preprocess2(RDR_adata, ref_celltype = ref_celltype, 
                                    cluster_key=cell_anno_key,
                                    avg_layer = "ref_avg", 
                                    depth_key=depth_key, 
                                    copy=True)
+        '''
 
     RDR_adata = xclone.model.RDR_smoothing_base(RDR_adata,
                                                 clip = True,

--- a/xclone/preprocessing/_RDR_preprocess.py
+++ b/xclone/preprocessing/_RDR_preprocess.py
@@ -91,11 +91,19 @@ def Xdata_RDR_preprocess(Xdata,
     #     return Xdata
     
     # reference data preprocessing
-    if ref_celltype is None:
-        raise ValueError("ref_celltype should be assigned! Pls check!")
+    # if ref_celltype is None:
+        # raise ValueError("ref_celltype should be assigned! Pls check!")
 
-    ref_flag = Xdata.obs[cell_anno_key] == ref_celltype
-    ref_Xdata = Xdata[ref_flag,:]
+    # ref_flag = Xdata.obs[cell_anno_key] == ref_celltype
+    # ref_Xdata = Xdata[ref_flag,:]
+
+    # modified for multiple ref_celltype
+    if isinstance(ref_celltype, list):
+        ref_flag = Xdata.obs[cell_anno_key].isin(ref_celltype)
+    else:
+        ref_flag = Xdata.obs[cell_anno_key] == ref_celltype
+
+    ref_Xdata = Xdata[ref_flag, :]
 
     Xdata.var[var_key] = ref_Xdata.X.toarray().mean(axis=0)
 
@@ -145,7 +153,14 @@ def Xdata_RDR_preprocess(Xdata,
     # mode="ALL"
     ## process both cellbased data and celltype based data.
     celltype_ad = rr_ad_celltype_processing(update_Xdata, ref_celltype, cell_anno_key)
-    is_ref = celltype_ad.obs[cell_anno_key] == ref_celltype
+
+    # is_ref = celltype_ad.obs[cell_anno_key] == ref_celltype
+    # modified for multiple ref_celltype
+    if isinstance(ref_celltype, list):
+        is_ref = celltype_ad.obs[cell_anno_key].isin(ref_celltype)
+    else:
+        is_ref = celltype_ad.obs[cell_anno_key] == ref_celltype
+    
 
     celltype_ad.var[var_key] = celltype_ad[is_ref,:].X.toarray()[0]
 
@@ -162,8 +177,16 @@ def rr_ad_celltype_processing(Xdata, ref_celltype, cell_anno_key):
     For pseudo bulk. celltype-based count.
     version:0.0.2
     """
-    ref_flag = Xdata.obs[cell_anno_key] == ref_celltype
-    ref_Xdata = Xdata[ref_flag,:]
+    # ref_flag = Xdata.obs[cell_anno_key] == ref_celltype
+    # ref_Xdata = Xdata[ref_flag,:]
+
+    # modified for multiple ref_celltype
+    if isinstance(ref_celltype, list):
+        ref_flag = Xdata.obs[cell_anno_key].isin(ref_celltype)
+    else:
+        ref_flag = Xdata.obs[cell_anno_key] == ref_celltype
+
+    ref_Xdata = Xdata[ref_flag, :]
     obs_Xdata = Xdata.copy()
 
     ref_bulk = ref_Xdata.X.toarray().sum(axis=0)
@@ -200,8 +223,14 @@ def rr_ad_cell_processing(Xdata, ref_celltype, cell_anno_key):
     """
     version:0.0.2
     """
-    ref_flag = Xdata.obs[cell_anno_key] == ref_celltype
-    ref_Xdata = Xdata[ref_flag,:]
+    # ref_flag = Xdata.obs[cell_anno_key] == ref_celltype
+    # modified for multiple ref_celltype
+    if isinstance(ref_celltype, list):
+        ref_flag = Xdata.obs[cell_anno_key].isin(ref_celltype)
+    else:
+        ref_flag = Xdata.obs[cell_anno_key] == ref_celltype
+
+    ref_Xdata = Xdata[ref_flag, :]
 
     obs_Xdata = Xdata
     


### PR DESCRIPTION
Modifications:

1. For all operations involving ref_celltype, modified to support both str and list. By doing so, all operations are the same for single and multiple references

2. Removed calling xclone.model.extra_preprocess2. It seems to be a function designed for multiple reference, after 1. , there is no need for this. Therefore, the setting xconfig.multi_refcelltype = True is also optional and does not affect any steps.