### PR TITLE
BAF phasing and combining improvements

### DIFF
--- a/xclone/_config.py
+++ b/xclone/_config.py
@@ -764,7 +764,7 @@ class Smartseq_Config():
             None
         """
 
-        if self.module == "RDR":
+        if self.module == "RDR" or self.module == "RDR_gaussian":
             self.smart_transform = True
             self.filter_ref_ave = 1.8
             ## HMM related
@@ -836,7 +836,7 @@ class Spatial_Config():
             None
         """
 
-        if self.module == "RDR":
+        if self.module == "RDR" or self.module == "RDR_gaussian":
             # self.spatail_imputation = True
             self.smart_transform = False
             self.spatial_transform = True

--- a/xclone/model/XClone_combine.py
+++ b/xclone/model/XClone_combine.py
@@ -492,19 +492,26 @@ def CNV_prob_merge(Xdata,
     ## BAF 3 states
     if prob_.shape[-1] == 3:
         copy_loss = prob_[:,:,0,:].sum(axis = -1)
-        loh = prob_[:,:,1,0] + prob_[:,:,1,2]
+        # loh = prob_[:,:,1,0] + prob_[:,:,1,2]
+        loh = np.maximum(prob_[:,:,1,0], prob_[:,:,1,2])
         copy_neutral = prob_[:,:,1,1] 
         copy_gain = prob_[:,:,2,:].sum(axis = -1)
     
     ## BAF 5 states
     if prob_.shape[-1] == 5:
         copy_loss = prob_[:,:,0,:].sum(axis = -1)
-        loh = prob_[:,:,1,0] + prob_[:,:,1,4]
+        # loh = prob_[:,:,1,0] + prob_[:,:,1,4]
+        loh = np.maximum(prob_[:,:,1,0], prob_[:,:,1,4])
         copy_neutral = prob_[:,:,1,2]
-        copy_gain_less = prob_[:,:,1,1] + prob_[:,:,1,3]
+        # copy_gain_less = prob_[:,:,1,1] + prob_[:,:,1,3]
+        copy_gain_less = np.maximum(prob_[:,:,1,1], prob_[:,:,1,3])
         copy_gain = prob_[:,:,2,:].sum(axis = -1) + copy_gain_less
 
     prob_merge = np.stack([copy_loss, loh, copy_neutral, copy_gain], axis = -1)
+
+    # Normalize
+    prob_merge = prob_merge / prob_merge.sum(axis=-1, keepdims=True)
+
     return prob_merge
 
 def CNV_prob_merge2(Xdata,
@@ -522,7 +529,8 @@ def CNV_prob_merge2(Xdata,
     ## BAF 3 states
     if prob_.shape[-1] == 3:
         copy_loss = prob_[:,:,0,:].sum(axis = -1)
-        loh = prob_[:,:,1,0] + prob_[:,:,1,2]
+        # loh = prob_[:,:,1,0] + prob_[:,:,1,2]
+        loh = np.maximum(prob_[:,:,1,0], prob_[:,:,1,2])
         copy_loss = copy_loss + loh
         copy_neutral = prob_[:,:,1,1] 
         copy_gain = prob_[:,:,2,:].sum(axis = -1)
@@ -530,25 +538,34 @@ def CNV_prob_merge2(Xdata,
     ## BAF 5 states
     if prob_.shape[-1] == 5:
         copy_loss = prob_[:,:,0,:].sum(axis = -1)
-        loh = prob_[:,:,1,0] + prob_[:,:,1,4]
+        # loh = prob_[:,:,1,0] + prob_[:,:,1,4]
+        loh = np.maximum(prob_[:,:,1,0], prob_[:,:,1,4])
         copy_loss = copy_loss + loh
         copy_neutral = prob_[:,:,1,2]
-        copy_gain_less = prob_[:,:,1,1] + prob_[:,:,1,3]
+        # copy_gain_less = prob_[:,:,1,1] + prob_[:,:,1,3]
+        copy_gain_less = np.maximum(prob_[:,:,1,1], prob_[:,:,1,3])
         copy_gain = prob_[:,:,2,:].sum(axis = -1) + copy_gain_less
 
     prob_merge = np.stack([copy_loss, loh, copy_neutral, copy_gain], axis = -1)
+
+    # Normalize
+    prob_merge = prob_merge / prob_merge.sum(axis=-1, keepdims=True)
+
     return prob_merge
+
 
 def CNV_prob_merge_for_plot(Xdata,
                             Xlayer = "corrected_prob"):
     """
     Merge states prob for more detailed evaluation and visualization.
+    Uses np.maximum for loh and copy_gain_less for both 3 and 5 states.
+    Normalizes merged probabilities so that sum across last axis is 1.
     """
     prob_ = Xdata.layers[Xlayer].copy()
     ## BAF 3 states
     if prob_.shape[-1] == 3:
         copy_loss = prob_[:,:,0,:].sum(axis = -1)
-        loh = prob_[:,:,1,0] + prob_[:,:,1,2]
+        loh = np.maximum(prob_[:,:,1,0], prob_[:,:,1,2])
         copy_neutral = prob_[:,:,1,1] 
         copy_gain = prob_[:,:,2,:].sum(axis = -1)
 
@@ -561,9 +578,9 @@ def CNV_prob_merge_for_plot(Xdata,
     ## BAF 5 states
     if prob_.shape[-1] == 5:
         copy_loss = prob_[:,:,0,:].sum(axis = -1)
-        loh = prob_[:,:,1,0] + prob_[:,:,1,4]
+        loh = np.maximum(prob_[:,:,1,0], prob_[:,:,1,4])
         copy_neutral = prob_[:,:,1,2]
-        copy_gain_less = prob_[:,:,1,1] + prob_[:,:,1,3]
+        copy_gain_less = np.maximum(prob_[:,:,1,1], prob_[:,:,1,3])
         copy_gain = prob_[:,:,2,:].sum(axis = -1) + copy_gain_less
 
         copy_loss_A = prob_[:,:,0,3] + prob_[:,:,0,4]
@@ -573,12 +590,20 @@ def CNV_prob_merge_for_plot(Xdata,
         loh_B = prob_[:,:,1,0]
 
     plot_prob_merge1 = np.stack([copy_loss, loh, copy_neutral, copy_gain], axis = -1)
-    Xdata.layers["plot_prob_merge1"] = plot_prob_merge1
+    plot_prob_merge1 = plot_prob_merge1 / plot_prob_merge1.sum(axis=-1, keepdims=True)
+
     plot_prob_merge2 = np.stack([copy_loss_A, copy_loss_B, loh, copy_neutral, copy_gain], axis = -1)
-    Xdata.layers["plot_prob_merge2"] = plot_prob_merge2
+    plot_prob_merge2 = plot_prob_merge2 / plot_prob_merge2.sum(axis=-1, keepdims=True)
+
     plot_prob_merge3 = np.stack([copy_loss_A, copy_loss_B, loh_A, loh_B, copy_neutral, copy_gain], axis = -1)
-    Xdata.layers["plot_prob_merge3"] = plot_prob_merge3
+    plot_prob_merge3 = plot_prob_merge3 / plot_prob_merge3.sum(axis=-1, keepdims=True)
+
     plot_prob_merge4 = np.stack([copy_loss, loh_A, loh_B, copy_neutral, copy_gain], axis = -1)
+    plot_prob_merge4 = plot_prob_merge4 / plot_prob_merge4.sum(axis=-1, keepdims=True)
+
+    Xdata.layers["plot_prob_merge1"] = plot_prob_merge1
+    Xdata.layers["plot_prob_merge2"] = plot_prob_merge2
+    Xdata.layers["plot_prob_merge3"] = plot_prob_merge3
     Xdata.layers["plot_prob_merge4"] = plot_prob_merge4
     
     return Xdata

--- a/xclone/model/xclone_rdr_gaussian.py
+++ b/xclone/model/xclone_rdr_gaussian.py
@@ -289,6 +289,7 @@ def run_RDR_gaussian(RDR_adata, verbose = True, config_file = None):
         print("[XClone hint] Low rank approximation applied to the HMM posterior probabilities.")
         print("[XClone hint] Layer '%s' contains the low rank approximation of HMM posterior probabilities." % layer_name)
 
+    RDR_adata.layers['posterior_mtx'] = RDR_adata.layers[layer_name]
     
     ## output after CNV calling, save data with CNV posterior.
     try:

--- a/xclone/model/xclone_rdr_gaussian.py
+++ b/xclone/model/xclone_rdr_gaussian.py
@@ -245,6 +245,7 @@ def run_RDR_gaussian(RDR_adata, verbose = True, config_file = None):
                                                  ref_celltype=ref_celltype,
                                                  sd_amplifier=denoise_sd_amplifier)    
     denoised_layer = layer_name
+
     ## GMM
     RDR_adata, layer_name = xclone.model.compute_gaussian_probabilities(RDR_adata, 
                                                                         layer=layer_name,
@@ -276,7 +277,7 @@ def run_RDR_gaussian(RDR_adata, verbose = True, config_file = None):
         print("[XClone RDR module] HMM posterior probabilities smoothed.")
         print("[XClone RDR module] Layer '%s' contains the smoothed HMM posterior probabilities." % layer_name)
 
-    ## optional low rank
+    ## recommended low rank
     if low_rank:
         RDR_adata, layer_name = xclone.model.low_rank_approximation(RDR_adata, 
                                                         layer=layer_name,


### PR DESCRIPTION
1. Improved global phasing of BAF, such that each bin will be compared with previous 5 bins instead of previous 1 bin. This avoids the issue of wrong flipping within each chromosome.
2. Improved RDR and BAF combining strategy to avoid false positive LOH signal after combining.
3. Fixed bugs.